### PR TITLE
Acme entrypoint for HTTP Challenge 

### DIFF
--- a/.config/traefik.toml
+++ b/.config/traefik.toml
@@ -1,7 +1,7 @@
 # Traefik configuration file
 # Replace #DOMAIN# with the base domain you would like Traefik to use
 # for reverse proxying.
-# 
+#
 # Replace #EMAIL_ADDRESS# with the email address you would like to receive
 # Let's Encrypt notifications at.
 
@@ -30,3 +30,6 @@ storage = "acme.json"
 entryPoint = "https"
 onHostRule = true
 onDemand = false
+
+[acme.httpChallenge]
+  entryPoint = "https"


### PR DESCRIPTION
# Purpose

In order for Acme to make a HTTP Challenge, to issue certificates, we set the default entrypoint to https.

# Adding an App: Implementation
N/A
- [ ] Added directory to `~/.containers/`.
- [ ] Added `.description` file to application directory.
- [ ] Added `$app.yaml` file to application directory.
- [ ] Added `$app-port.yaml` file to application directory.
- [ ] Added `$app-traefik.yaml` file to application directory.
- [ ] Added `$app-x86_64.yaml` file to application directory.
- [ ] Added details to documentation in `/docs/data/supported_services.yml`.
- [ ] Added detail page to documentation in `/docs/_docs/services/$app`

# Bugfix or Enhancement:

Fixing problem with certificates not being generated. This problem is because ACME v2 requires an `/.well-known` directory, and without the `acme.httpChallenge` directive it seem to fail.

# Requirements
- [X] I have read and agree to the [Contributor Covenant Code of Conduct](https://github.com/joskore/media-docker/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have confirmed that all changes adhere to the [Contributing Guidelines](https://github.com/joskore/media-docker/blob/master/.github/CONTRIBUTING.md).
- [X] I have confirmed that all defined tests pass prior to opening this pull request.

Thanks for contributing!