### PR TITLE
Update self_update.sh

### DIFF
--- a/.config/.env
+++ b/.config/.env
@@ -1,8 +1,10 @@
+REPOSITORY=https://github.com/joskore/media-docker
+BRANCH=master
 USER_NAME=
 PASSWORD=
 EMAIL_ADDRESS=
 HOSTNAME=
-TIMEZONE=America/NewYork
+TIMEZONE=America/New_York
 PLEX_CLAIM_TOKEN=
 BASE_DIR=
 MEDIA_DIR=

--- a/.scripts/self_update.sh
+++ b/.scripts/self_update.sh
@@ -13,7 +13,7 @@ self_update() {
   else
     info "Git repository not in place, installing."
     sudo rm -r "${DIRECTORY}" && mkdir "${DIRECTORY}" && cd "${DIRECTORY}"
-    sudo git clone https://github.com/joskore/media-docker/ "${DIRECTORY}"
+    git clone https://github.com/joskore/media-docker/ "${DIRECTORY}"
   fi
 
   cd "${DIRECTORY}"

--- a/.scripts/self_update.sh
+++ b/.scripts/self_update.sh
@@ -18,7 +18,7 @@ self_update() {
 
   cd "${DIRECTORY}"
 
-  sudo chmod +x "${DIRECTORY}/${SOURCENAME}" \
+  sudo chmod +x "${SOURCENAME}" \
     > /dev/null 2>&1 \
       || err "Error occurred while making $SOURCENAME executable."
 }

--- a/.scripts/self_update.sh
+++ b/.scripts/self_update.sh
@@ -3,17 +3,23 @@ set -euo pipefail
 
 self_update() {
   local DIRECTORY
+  local REPO
+  local BRANCH
+
   DIRECTORY=${1:-}
+  REPO="$(run_sh "$SCRIPTDIR" "env_get" "REPOSITORY")"
+  BRANCH="$(run_sh "$SCRIPTDIR" "env_get" "BRANCH")"
+
   info "Updating media-docker from Git."
 
   if [ -d "${DIRECTORY}/.git/" ] ; then
     info "Pulling changes from Git."
-    sudo git -C "${DIRECTORY}" pull origin master \
+    sudo git -C "${DIRECTORY}" pull origin "${REPO}" \
       > /dev/null 2>&1 || err "Error occured when updating from Git."
   else
     info "Git repository not in place, installing."
     sudo rm -r "${DIRECTORY}" && mkdir "${DIRECTORY}" && cd "${DIRECTORY}"
-    git clone https://github.com/joskore/media-docker/ "${DIRECTORY}"
+    git clone -b "${BRANCH}" "${REPO}" "${DIRECTORY}"
   fi
 
   cd "${DIRECTORY}"


### PR DESCRIPTION
fix reference to file for chmod

# Purpose

Self update process will never complete successfully, fails on chmod of media-docker.sh

# Bugfix or Enhancement:

Determined that the root cause was a bad filepath reference. Was adding base directory to the full path, duplicating the path and trying to chmod something that won't ever exist.

- [X] Updated file reference for chmod to not include the initial base dir and use only the source name.

# Requirements

Please ensure your pull request adheres to the following guidelines:

- [x] I have read and agree to the [Contributor Covenant Code of Conduct](https://github.com/joskore/media-docker/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have confirmed that all changes adhere to the [Contributing Guidelines](https://github.com/joskore/media-docker/blob/master/.github/CONTRIBUTING.md).
- [X] I have confirmed that all defined tests pass prior to opening this pull request.

Thanks for contributing!