### PR TITLE
Update nzbget.yaml

### DIFF
--- a/.containers/nzbget/nzbget.yaml
+++ b/.containers/nzbget/nzbget.yaml
@@ -4,7 +4,7 @@ services:
     container_name: nzbget
     volumes:
       - ${BASE_DIR}/nzbget/config:/config
-      - ${DOWNLOAD_DIR}/nzbget:/downloads
+      - ${DOWNLOAD_DIR}:/downloads
     environment:
       - PUID=${PUID}
       - PGID=${PGID}


### PR DESCRIPTION
# Purpose

Enable NZBGet users to not need to set up directory mappings in searcher apps.

# Bugfix or Enhancement:

- [X] Remove sub-directory from download volume mapping of nzbget service

# Requirements

Please ensure your pull request adheres to the following guidelines:

- [X] I have read and agree to the [Contributor Covenant Code of Conduct](https://github.com/joskore/media-docker/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have confirmed that all changes adhere to the [Contributing Guidelines](https://github.com/joskore/media-docker/blob/master/.github/CONTRIBUTING.md).
- [X] I have confirmed that all defined tests pass prior to opening this pull request.

Thanks for contributing!